### PR TITLE
Removed deepcopy to improve performance

### DIFF
--- a/CS3243_P2_Sudoku_XX.py
+++ b/CS3243_P2_Sudoku_XX.py
@@ -69,7 +69,12 @@ class Sudoku(object):
     def __init__(self, puzzle):
         # you may add more attributes if you need
         self.puzzle = puzzle # self.puzzle is a list of lists
-        self.ans = copy.deepcopy(puzzle) # self.ans is a list of lists
+        self.ans = self.copy(puzzle) # self.ans is a list of lists
+
+    def copy(self, puzzle):
+        new_puzzle = [[x for x in row] for row in puzzle]
+        return new_puzzle
+
 
     def runAC3(self, csp):
         qu = self.getConstraints(csp)


### PR DESCRIPTION
Tested before that `copy.deepcopy()` is rather slow as it recursively copies everything. This PR replaces it with a custom copy function for lists of lists.